### PR TITLE
Closes #5

### DIFF
--- a/.config/configstore/update-notifier-npm.json
+++ b/.config/configstore/update-notifier-npm.json
@@ -1,4 +1,4 @@
 {
 	"optOut": false,
-	"lastUpdateCheck": 1517441542389
+	"lastUpdateCheck": 1520633330968
 }

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const manuscript = require('manuscript-api')
 const app = express();
 const querystring = require('querystring');
 const bodyParser = require('body-parser');
+const setup = require('./setup.js');
 
 app.engine('handlebars', exphbs({defaultLayout: 'main'}));
 app.set('view engine', 'handlebars');
@@ -29,6 +30,7 @@ app.post("/", (request, response) => {
       site: `https://${request.body.site}`,
       token: request.body.token
     })
+    setup.isFirstRun(request.body.site, request.body.token);
     return response.redirect(`/?${query}`);
 })
 

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,26 @@
+// setup.js
+// Checks for first-run criteria and, if present, sets up the integration.
+
+// Check to see if 🗝️.env contains a site name and API token.
+function checkIfAppSecretsExist() {
+  if (process.env.SITE_NAME.length + process.env.API_TOKEN.length > 0) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+// Set up the integration when it's first run.
+function setupIntegration(site, token) {
+  // We need to include the protocol for API requests.
+  process.env.SITE_NAME = 'https://' + site;
+  process.env.API_TOKEN = token;
+}
+
+// Export a named function that checks for first-run status.
+module.exports.isFirstRun = function (site, token) {
+  if (!checkIfAppSecretsExist()) {
+    setupIntegration(site, token);
+  }
+}


### PR DESCRIPTION
When the use clicks on the integration tile in Manuscript, the app will check to see if the app secrets (site name and API token) exist in `🗝.env` and, if they don't, will write them there.